### PR TITLE
feat!: upgrade to AI SDK v6 (peer dep ai ^6.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apertis/ai-sdk-provider",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Apertis AI provider for Vercel AI SDK",
   "license": "Apache-2.0",
   "repository": {
@@ -33,7 +33,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@ai-sdk/openai-compatible": "^1.0.30"
+    "@ai-sdk/openai-compatible": "^2.0.41"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
@@ -43,8 +43,8 @@
     "vitest": "^2.0.0"
   },
   "peerDependencies": {
-    "ai": ">=5.0.0",
-    "zod": "^3.0.0"
+    "ai": "^6.0.0",
+    "zod": "^3.25.76 || ^4.1.8"
   },
   "keywords": [
     "ai",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,13 +9,13 @@ importers:
   .:
     dependencies:
       '@ai-sdk/openai-compatible':
-        specifier: ^1.0.30
-        version: 1.0.30(zod@3.25.76)
+        specifier: ^2.0.41
+        version: 2.0.41(zod@3.25.76)
       ai:
-        specifier: '>=5.0.0'
+        specifier: ^6.0.0
         version: 6.0.42(zod@3.25.76)
       zod:
-        specifier: ^3.0.0
+        specifier: ^3.25.76 || ^4.1.8
         version: 3.25.76
     devDependencies:
       '@biomejs/biome':
@@ -42,14 +42,14 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@1.0.30':
-    resolution: {integrity: sha512-thubwhRtv9uicAxSWwNpinM7hiL/0CkhL/ymPaHuKvI494J7HIzn8KQZQ2ymRz284WTIZnI7VMyyejxW4RMM6w==}
+  '@ai-sdk/openai-compatible@2.0.41':
+    resolution: {integrity: sha512-kNAGINk71AlOXx10Dq/PXw4t/9XjdK8uxfpVElRwtSFMdeSiLVt58p9TPx4/FJD+hxZuVhvxYj9r42osxWq79g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@3.0.20':
-    resolution: {integrity: sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ==}
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -60,12 +60,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@2.0.1':
-    resolution: {integrity: sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==}
-    engines: {node: '>=18'}
-
   '@ai-sdk/provider@3.0.4':
     resolution: {integrity: sha512-5KXyBOSEX+l67elrEa+wqo/LSsSTtrPj9Uoh3zMbe/ceQX4ucHI3b9nUEfNkGF3Ry1svv90widAt+aiKdIJasQ==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
   '@biomejs/biome@1.9.4':
@@ -971,15 +971,15 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
-  '@ai-sdk/openai-compatible@1.0.30(zod@3.25.76)':
+  '@ai-sdk/openai-compatible@2.0.41(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@3.0.20(zod@3.25.76)':
+  '@ai-sdk/provider-utils@4.0.23(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
@@ -991,11 +991,11 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
-  '@ai-sdk/provider@2.0.1':
+  '@ai-sdk/provider@3.0.4':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@3.0.4':
+  '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 


### PR DESCRIPTION
## Summary
Upgrades the SDK to be compatible with Vercel AI SDK v6.

- Bumps peer dep \`ai\`: \`>=5.0.0\` → \`^6.0.0\`
- Bumps internal \`@ai-sdk/openai-compatible\`: \`^1.0.30\` → \`^2.0.41\`
- Bumps zod peer range to \`^3.25.76 || ^4.1.8\` (matches openai-compatible v2)
- Version: \`2.1.0\` → \`3.0.0\` (major — peer dep break)

Models now emit AI SDK \`v3\` LanguageModel spec (was \`v2\`).

## Why
Required for downstream consumers on AI SDK v6 (e.g. opencode), which type-rejects \`v2\` providers when registering bundled SDKs.

## Test plan
- [x] \`pnpm test:run\` — 5/5 pass
- [x] \`tsc --noEmit\` — clean
- [x] \`pnpm build\` — dist 130KB
- [ ] After merge, cut \`v3.0.0\` release to trigger publish workflow