### PR TITLE
chore(ci): switch publish to OIDC trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Publish to npm
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Publish to npm (OIDC trusted publisher)
+        run: npm publish --access public


### PR DESCRIPTION
## Summary
Replaces \`NPM_TOKEN\` in publish.yml with npm's OIDC trusted publisher flow, ending long-lived token rotation pain.

## Changes
- \`npm publish\` no longer uses \`NODE_AUTH_TOKEN\` env
- Adds \`npm install -g npm@latest\` step (OIDC needs npm >= 11.5)
- \`--provenance\` is now implied automatically by trusted publisher

## Prerequisites
Trusted publisher already configured on npmjs.com for this repo + workflow.

## Test plan
- [ ] Re-run failed publish workflow on \`v3.0.0\` release after merge — should succeed